### PR TITLE
support note and custom reporting of events

### DIFF
--- a/markdownReporter.js
+++ b/markdownReporter.js
@@ -54,6 +54,16 @@ module.exports = class MarkdownReporter {
 
     }
 
+    note(event){
+        this.logger.info(`### Note \r\n ${event.eventData.message}`);
+
+    }
+
+    custom(event){
+        this.logger.info(`### ${event.eventData.title} \r\n ${event.eventData.message}`);
+
+    }
+
 
 
     storeImage(imgName, base64Data){

--- a/testSession.js
+++ b/testSession.js
@@ -14,7 +14,8 @@ module.exports = class TestSession {
 
     async start(browser, initialUrl){
          this.q = new Queue((event, cb)=>{
-            this.reporter[event.eventType](event);
+             const reportFunc= this.reporter[event.eventType] || this.reporter.custom;
+             reportFunc(event);
             cb(null,Date.now());
         });
 


### PR DESCRIPTION
reporter checks for method to handle an eventType. If no handler the `custom` method is used. 
